### PR TITLE
Add symlink org.gnome.Console -> org.gnome.Terminal

### DIFF
--- a/kora/apps/scalable/org.gnome.Console.svg
+++ b/kora/apps/scalable/org.gnome.Console.svg
@@ -1,0 +1,1 @@
+org.gnome.Terminal.svg


### PR DESCRIPTION
Gnome Console is the new default terminal in Gnome 42.
It is very similar to the previous Gnome Terminal app, I think it makes sense to use the same icon as Terminal for now.