### PR TITLE
Fixed two broken symlinks

### DIFF
--- a/kora/mimetypes/scalable/application-sweethome3d.svg
+++ b/kora/mimetypes/scalable/application-sweethome3d.svg
@@ -1,1 +1,1 @@
-../apps/sweethome3d.svg
+../../apps/scalable/sweethome3d.svg

--- a/kora/mimetypes/scalable/application-vnd.insync.link.drive.link.svg
+++ b/kora/mimetypes/scalable/application-vnd.insync.link.drive.link.svg
@@ -1,1 +1,1 @@
-../apps/google-drive.svg
+../../apps/scalable/google-drive.svg


### PR DESCRIPTION
Congratulation on this beautiful icon theme!
I've fixed two broken symlinks:
```bash
./kora/mimetypes/scalable/application-sweethome3d.svg
./kora/mimetypes/scalable/application-vnd.insync.link.drive.link.svg
```
Now they are pointing to `../../apps/scalable/` rather than `../apps/`