### PR TITLE
Added Go programming language folder icon

### DIFF
--- a/kora/places/scalable/folder-go.svg
+++ b/kora/places/scalable/folder-go.svg
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="/tmp/ink_ext_XXXXXX.svgYN8H21"
+   inkscape:export-filename="bitmap.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview403"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:zoom="0.25"
+     inkscape:cx="90.5"
+     inkscape:cy="90.5"
+     inkscape:window-width="1610"
+     inkscape:window-height="1080"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid409" />
+  </sodipodi:namedview>
+  <defs
+     id="defs398">
+    <linearGradient
+       id="_Linear1"
+       x2="1"
+       gradientTransform="matrix(0,-41.6338,41.6338,0,445.153,52.7218)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         style="stop-color:rgb(16,117,246)"
+         offset="0"
+         id="stop10" />
+      <stop
+         style="stop-color:rgb(18,197,255)"
+         offset="1"
+         id="stop12" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       transform="matrix(0.75,0,0,0.75,-0.2316947,0.0961445)"
+       id="g4"
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+      <path
+         d="m 61.122,15.88 c 0,-2.762 -2.239,-5 -5,-5 H 7.878 c -2.761,0 -5,2.238 -5,5 v 32.246 c 0,2.761 2.239,5 5,5 h 48.244 c 2.761,0 5,-2.239 5,-5 z"
+         style="fill:#0083d5"
+         id="path2" />
+    </g>
+    <g
+       transform="matrix(0.75,0,0,0.75,-0.2316947,0.0961445)"
+       id="g8"
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+      <path
+         d="m 61.122,20.652 c 0,-1.326 -0.527,-2.598 -1.465,-3.536 -0.938,-0.937 -2.209,-1.464 -3.535,-1.464 h -25.58 c -1.232,0 -2.42,-0.455 -3.337,-1.277 -0.768,-0.689 -1.713,-1.535 -2.481,-2.224 -0.917,-0.822 -2.105,-1.277 -3.337,-1.277 H 7.878 c -1.326,0 -2.597,0.527 -3.535,1.465 -0.938,0.937 -1.465,2.209 -1.465,3.535 v 32.252 c 0,2.761 2.239,5 5,5 h 48.244 c 2.761,0 5,-2.239 5,-5 z"
+         style="fill:url(#_Linear1)"
+         id="path6" />
+    </g>
+    <g
+       id="g598"
+       transform="matrix(0.18967951,0,0,0.2341582,-1.0686003,-1.4384845)"
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+	<g
+   id="g567">
+		<g
+   id="g565">
+			<g
+   id="g563">
+				<path
+   d="m 40.2,101.1 c -0.4,0 -0.5,-0.2 -0.3,-0.5 L 42,97.9 c 0.2,-0.3 0.7,-0.5 1.1,-0.5 h 35.7 c 0.4,0 0.5,0.3 0.3,0.6 l -1.7,2.6 c -0.2,0.3 -0.7,0.6 -1,0.6 z"
+   fill="#106597"
+   id="path561" />
+
+			</g>
+
+		</g>
+
+	</g>
+
+	<g
+   id="g575">
+		<g
+   id="g573">
+			<g
+   id="g571">
+				<path
+   d="m 25.1,110.3 c -0.4,0 -0.5,-0.2 -0.3,-0.5 l 2.1,-2.7 c 0.2,-0.3 0.7,-0.5 1.1,-0.5 h 45.6 c 0.4,0 0.6,0.3 0.5,0.6 l -0.8,2.4 c -0.1,0.4 -0.5,0.6 -0.9,0.6 z"
+   fill="#106597"
+   id="path569" />
+
+			</g>
+
+		</g>
+
+	</g>
+
+	<g
+   id="g583">
+		<g
+   id="g581">
+			<g
+   id="g579">
+				<path
+   d="m 49.3,119.5 c -0.4,0 -0.5,-0.3 -0.3,-0.6 l 1.4,-2.5 c 0.2,-0.3 0.6,-0.6 1,-0.6 h 20 c 0.4,0 0.6,0.3 0.6,0.7 l -0.2,2.4 c 0,0.4 -0.4,0.7 -0.7,0.7 z"
+   fill="#106597"
+   id="path577" />
+
+			</g>
+
+		</g>
+
+	</g>
+
+	<g
+   id="g596">
+		<g
+   id="CXHf1q_5_">
+			<g
+   id="g593">
+				<g
+   id="g587">
+					<path
+   d="m 153.1,99.3 c -6.3,1.6 -10.6,2.8 -16.8,4.4 -1.5,0.4 -1.6,0.5 -2.9,-1 -1.5,-1.7 -2.6,-2.8 -4.7,-3.8 -6.3,-3.1 -12.4,-2.2 -18.1,1.5 -6.8,4.4 -10.3,10.9 -10.2,19 0.1,8 5.6,14.6 13.5,15.7 6.8,0.9 12.5,-1.5 17,-6.6 0.9,-1.1 1.7,-2.3 2.7,-3.7 -3.6,0 -8.1,0 -19.3,0 -2.1,0 -2.6,-1.3 -1.9,-3 1.3,-3.1 3.7,-8.3 5.1,-10.9 0.3,-0.6 1,-1.6 2.5,-1.6 5.1,0 23.9,0 36.4,0 -0.2,2.7 -0.2,5.4 -0.6,8.1 -1.1,7.2 -3.8,13.8 -8.2,19.6 -7.2,9.5 -16.6,15.4 -28.5,17 -9.8,1.3 -18.9,-0.6 -26.9,-6.6 -7.4,-5.6 -11.6,-13 -12.7,-22.2 -1.3,-10.9 1.9,-20.7 8.5,-29.3 7.1,-9.3 16.5,-15.2 28,-17.3 9.4,-1.7 18.4,-0.6 26.5,4.9 5.3,3.5 9.1,8.3 11.6,14.1 0.6,0.9 0.2,1.4 -1,1.7 z"
+   fill="#106597"
+   id="path585" />
+
+				</g>
+
+				<g
+   id="g591">
+					<path
+   d="m 186.2,154.6 c -9.1,-0.2 -17.4,-2.8 -24.4,-8.8 -5.9,-5.1 -9.6,-11.6 -10.8,-19.3 -1.8,-11.3 1.3,-21.3 8.1,-30.2 7.3,-9.6 16.1,-14.6 28,-16.7 10.2,-1.8 19.8,-0.8 28.5,5.1 7.9,5.4 12.8,12.7 14.1,22.3 1.7,13.5 -2.2,24.5 -11.5,33.9 -6.6,6.7 -14.7,10.9 -24,12.8 -2.7,0.5 -5.4,0.6 -8,0.9 z M 210,114.2 c -0.1,-1.3 -0.1,-2.3 -0.3,-3.3 -1.8,-9.9 -10.9,-15.5 -20.4,-13.3 -9.3,2.1 -15.3,8 -17.5,17.4 -1.8,7.8 2,15.7 9.2,18.9 5.5,2.4 11,2.1 16.3,-0.6 7.9,-4.1 12.2,-10.5 12.7,-19.1 z"
+   fill="#106597"
+   id="path589" />
+
+				</g>
+
+			</g>
+
+		</g>
+
+	</g>
+
+</g>
+  </g>
+</svg>


### PR DESCRIPTION
This pull request adds a new folder icon for Go programming language projects. The current folder icon does not reflect the specific needs of Go projects, and this new icon will help users to more easily identify their Go project folders.

The new icon was designed using Inkscape and is included in the "go-icon.svg" file. The icon has been optimized for display at a size of 48x48 pixels. Thank you for your consideration.