### PR TITLE
Fix #126 and #152

### DIFF
--- a/kora-light-panel/index.theme
+++ b/kora-light-panel/index.theme
@@ -30,9 +30,9 @@ DialogSizes=16,22,32,48,64,128,256
 
 
 ########## DIRECTORY LIST
-########## ordered by category and alphabetically
+########## ordered by category
 
-Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,places/scalable,places/scalable@2,places/symbolic,status/scalable,status/scalable@2,status/symbolic
+Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,places/scalable,places/scalable@2,places/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,status/scalable,status/scalable@2,status/symbolic
 
 
 

--- a/kora-light/index.theme
+++ b/kora-light/index.theme
@@ -30,9 +30,9 @@ DialogSizes=16,22,32,48,64,128,256
 
 
 ########## DIRECTORY LIST
-########## ordered by category and alphabetically
+########## ordered by category
 
-Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,places/scalable,places/scalable@2,places/symbolic,status/scalable,status/scalable@2,status/symbolic
+Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,places/scalable,places/scalable@2,places/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,status/scalable,status/scalable@2,status/symbolic
 
 
 

--- a/kora-pgrey/index.theme
+++ b/kora-pgrey/index.theme
@@ -30,9 +30,8 @@ DialogSizes=16,22,32,48,64,128,256
 
 
 ########## DIRECTORY LIST
-########## ordered by category and alphabetically
-
-Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,places/scalable,places/scalable@2,places/symbolic,status/scalable,status/scalable@2,status/symbolic
+########## ordered by category
+Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,places/scalable,places/scalable@2,places/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,status/scalable,status/scalable@2,status/symbolic
 
 
 

--- a/kora-pgrey/index.theme
+++ b/kora-pgrey/index.theme
@@ -31,6 +31,7 @@ DialogSizes=16,22,32,48,64,128,256
 
 ########## DIRECTORY LIST
 ########## ordered by category
+
 Directories=actions/16,actions/16@2,actions/symbolic,animations/scalable,animations/scalable@2,apps/scalable,apps/scalable@2,apps/symbolic,categories/scalable,categories/scalable@2,categories/symbolic,devices/scalable,devices/scalable@2,devices/symbolic,emblems/scalable,emblems/scalable@2,emblems/symbolic,emotes/scalable,emotes/symbolic,places/scalable,places/scalable@2,places/symbolic,mimetypes/scalable,mimetypes/scalable@2,mimetypes/symbolic,panel/16,panel/16@2,panel/22,panel/22@2,panel/24,panel/24@2,status/scalable,status/scalable@2,status/symbolic
 
 


### PR DESCRIPTION
Fix #126 and #152

It looks like the problem is that the symlink `kora-pgray/mimetypes/scalable/inode-directory.svg` resolves into `kora/places/scalable/folder.svg` instead of `kora-pgray/places/scalable/folder.svg`. Apparently, according to the [freedesktop Icon Lookup](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#icon_lookup) the selected icon is the blue one. To fix it, one alternative is to place `places` icons before `mimetypes` icons in the directory list in `index.theme` file. This way, `kora-pgray/places/scalable/folder.svg` takes priority over `kora-pgray/mimetypes/scalable/inode-directory.svg`