### PR TITLE
Delete kora/apps/scalable/urxvt (copy).svg

### DIFF
--- a/kora/apps/scalable/urxvt (copy).svg
+++ b/kora/apps/scalable/urxvt (copy).svg
@@ -1,1 +1,0 @@
-terminal.svg


### PR DESCRIPTION
I found this file when I tried to refresh the icon cache and an error occurred. It looks like an accidental copy of the icon