### PR TITLE
Add symbolic monochrome VLC icon from Breeze

### DIFF
--- a/kora/apps/symbolic/vlc-symbolic.svg
+++ b/kora/apps/symbolic/vlc-symbolic.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg9"
+   sodipodi:docname="vlc.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13" />
+  <sodipodi:namedview
+     id="namedview11"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.136364"
+     inkscape:cx="9.4773609"
+     inkscape:cy="9.0504528"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg9" />
+  <style
+     type="text/css"
+     id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#31363b;
+      }
+      </style>
+  <g
+     id="vlc"
+     transform="translate(0,-1030.3621)">
+    <rect
+       y="1030.3621"
+       x="0"
+       height="22"
+       width="22"
+       id="rect4246"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       class="ColorScheme-Text" />
+    <rect
+       style="opacity:1;fill:currentColor;fill-opacity:1;stroke:none;stroke-width:3.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4271"
+       width="16"
+       height="2"
+       x="3"
+       y="1047.3621"
+       class="ColorScheme-Text" />
+    <path
+       style="opacity:1;fill:currentColor;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 9.1191406,1033.3613 -4.1015625,14.8672 0.9648438,0.2656 3.8984375,-14.1328 h 2.2382816 l 3.898437,14.1328 0.964844,-0.2656 -4.101563,-14.8672 z"
+       id="path4273"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+    <path
+       style="fill:currentColor;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,1036.3621 h 4 l 1,3 H 8 Z"
+       id="path4275"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+    <path
+       style="fill:currentColor;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.5,1042.3621 h 7 l 1,3 h -9 z"
+       id="path4277"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+  </g>
+</svg>


### PR DESCRIPTION
I was annoyed by the VLC icons being the only one that wasn't monochrome for me. The Breeze icons blends in nicely with the rest.

![grafik](https://github.com/user-attachments/assets/a1621fe5-72c4-4205-8b2f-2e239dee6636)
