### PR TITLE
Fix Dolphin's side panel not loading symbolic icons

### DIFF
--- a/kora/actions/symbolic/kdeconnect.svg
+++ b/kora/actions/symbolic/kdeconnect.svg
@@ -1,0 +1,1 @@
+../16/kdeconnect.svg

--- a/kora/index.theme
+++ b/kora/index.theme
@@ -84,8 +84,8 @@ Type=Scalable
 
 [apps/scalable]
 Context=Applications
-Size=16
-MinSize=8
+Size=24
+MinSize=24
 MaxSize=512
 Type=Scalable
 
@@ -144,8 +144,8 @@ Type=Scalable
 
 [devices/scalable]
 Context=Devices
-Size=16
-MinSize=8
+Size=24
+MinSize=24
 MaxSize=512
 Type=Scalable
 
@@ -285,8 +285,8 @@ Type=Fixed
 
 [places/scalable]
 Context=Places
-Size=16
-MinSize=8
+Size=24
+MinSize=24
 MaxSize=512
 Type=Scalable
 

--- a/kora/places/symbolic/document-open-recent.svg
+++ b/kora/places/symbolic/document-open-recent.svg
@@ -1,0 +1,1 @@
+document-open-recent-symbolic.svg

--- a/kora/places/symbolic/drive-harddisk-root.svg
+++ b/kora/places/symbolic/drive-harddisk-root.svg
@@ -1,0 +1,1 @@
+drive-harddisk-symbolic.svg

--- a/kora/places/symbolic/drive-harddisk-system-symbolic.svg
+++ b/kora/places/symbolic/drive-harddisk-system-symbolic.svg
@@ -1,0 +1,1 @@
+drive-harddisk-symbolic.svg

--- a/kora/places/symbolic/drive-harddisk-system.svg
+++ b/kora/places/symbolic/drive-harddisk-system.svg
@@ -1,0 +1,1 @@
+drive-harddisk-symbolic.svg

--- a/kora/places/symbolic/drive-harddisk-usb.svg
+++ b/kora/places/symbolic/drive-harddisk-usb.svg
@@ -1,0 +1,1 @@
+drive-harddisk-usb-symbolic.svg

--- a/kora/places/symbolic/drive-harddisk.svg
+++ b/kora/places/symbolic/drive-harddisk.svg
@@ -1,0 +1,1 @@
+drive-harddisk-symbolic.svg

--- a/kora/places/symbolic/drive-removable-media-usb.svg
+++ b/kora/places/symbolic/drive-removable-media-usb.svg
@@ -1,0 +1,1 @@
+drive-removable-media-symbolic.svg

--- a/kora/places/symbolic/drive-removable-media.svg
+++ b/kora/places/symbolic/drive-removable-media.svg
@@ -1,0 +1,1 @@
+drive-removable-media-symbolic.svg

--- a/kora/places/symbolic/folder-documents.svg
+++ b/kora/places/symbolic/folder-documents.svg
@@ -1,0 +1,1 @@
+folder-documents-symbolic.svg

--- a/kora/places/symbolic/folder-download.svg
+++ b/kora/places/symbolic/folder-download.svg
@@ -1,0 +1,1 @@
+folder-download-symbolic.svg

--- a/kora/places/symbolic/folder-downloads.svg
+++ b/kora/places/symbolic/folder-downloads.svg
@@ -1,0 +1,1 @@
+folder-download-symbolic.svg

--- a/kora/places/symbolic/folder-music.svg
+++ b/kora/places/symbolic/folder-music.svg
@@ -1,0 +1,1 @@
+folder-music-symbolic.svg

--- a/kora/places/symbolic/folder-network.svg
+++ b/kora/places/symbolic/folder-network.svg
@@ -1,0 +1,1 @@
+network-workgroup-symbolic.svg

--- a/kora/places/symbolic/folder-new.svg
+++ b/kora/places/symbolic/folder-new.svg
@@ -1,0 +1,1 @@
+folder-new-symbolic.svg

--- a/kora/places/symbolic/folder-open.svg
+++ b/kora/places/symbolic/folder-open.svg
@@ -1,0 +1,1 @@
+folder-open-symbolic.svg

--- a/kora/places/symbolic/folder-pictures.svg
+++ b/kora/places/symbolic/folder-pictures.svg
@@ -1,0 +1,1 @@
+folder-pictures-symbolic.svg

--- a/kora/places/symbolic/folder-publicshare.svg
+++ b/kora/places/symbolic/folder-publicshare.svg
@@ -1,0 +1,1 @@
+folder-publicshare-symbolic.svg

--- a/kora/places/symbolic/folder-remote.svg
+++ b/kora/places/symbolic/folder-remote.svg
@@ -1,0 +1,1 @@
+folder-remote-symbolic.svg

--- a/kora/places/symbolic/folder-saved-search.svg
+++ b/kora/places/symbolic/folder-saved-search.svg
@@ -1,0 +1,1 @@
+folder-saved-search-symbolic.svg

--- a/kora/places/symbolic/folder-templates.svg
+++ b/kora/places/symbolic/folder-templates.svg
@@ -1,0 +1,1 @@
+folder-templates-symbolic.svg

--- a/kora/places/symbolic/folder-videos.svg
+++ b/kora/places/symbolic/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-videos-symbolic.svg

--- a/kora/places/symbolic/folder-visiting.svg
+++ b/kora/places/symbolic/folder-visiting.svg
@@ -1,0 +1,1 @@
+folder-visiting-symbolic.svg

--- a/kora/places/symbolic/folder.svg
+++ b/kora/places/symbolic/folder.svg
@@ -1,0 +1,1 @@
+folder-symbolic.svg

--- a/kora/places/symbolic/multimedia-player.svg
+++ b/kora/places/symbolic/multimedia-player.svg
@@ -1,0 +1,1 @@
+multimedia-player-symbolic.svg

--- a/kora/places/symbolic/network-server.svg
+++ b/kora/places/symbolic/network-server.svg
@@ -1,0 +1,1 @@
+network-server-symbolic.svg

--- a/kora/places/symbolic/network-workgroup.svg
+++ b/kora/places/symbolic/network-workgroup.svg
@@ -1,0 +1,1 @@
+network-workgroup-symbolic.svg

--- a/kora/places/symbolic/user-desktop.svg
+++ b/kora/places/symbolic/user-desktop.svg
@@ -1,0 +1,1 @@
+user-desktop-symbolic.svg

--- a/kora/places/symbolic/user-home.svg
+++ b/kora/places/symbolic/user-home.svg
@@ -1,0 +1,1 @@
+user-home-symbolic.svg

--- a/kora/places/symbolic/user-trash-full-symbolic.svg
+++ b/kora/places/symbolic/user-trash-full-symbolic.svg
@@ -1,0 +1,1 @@
+user-trash-symbolic.svg

--- a/kora/places/symbolic/user-trash-full.svg
+++ b/kora/places/symbolic/user-trash-full.svg
@@ -1,0 +1,1 @@
+user-trash-symbolic.svg

--- a/kora/places/symbolic/user-trash.svg
+++ b/kora/places/symbolic/user-trash.svg
@@ -1,0 +1,1 @@
+user-trash-symbolic.svg


### PR DESCRIPTION
drive-harddisk from panel subfolders are still taking precedence over place's one